### PR TITLE
Fix stack overflow and plain object detection

### DIFF
--- a/pkg/apimodel/parse.go
+++ b/pkg/apimodel/parse.go
@@ -110,7 +110,7 @@ func (api *API) eval() error {
 
 	// Populate the base object maps
 	for shapeName, shapeSpec := range spec.Shapes {
-		comps.Schemas[shapeName] = oai.NewSchemaRef("", shapeSpec.Schema(swagger, &spec.Shapes))
+		comps.Schemas[shapeName] = oai.NewSchemaRef("", shapeSpec.Schema(shapeName, swagger, &spec.Shapes, []string{}))
 		// Determine simple types like scalars, lists and exceptions
 		if shapeSpec.Type != "structure" && shapeSpec.Type != "list" {
 			api.scalars[shapeName] = true

--- a/pkg/apimodel/parse.go
+++ b/pkg/apimodel/parse.go
@@ -119,12 +119,21 @@ func (api *API) eval() error {
 				Type:     ObjectTypeScalar,
 				DataType: shapeSpec.Type,
 			}
-		} else if shapeSpec.Type == "structure" && shapeSpec.Exception {
-			api.exceptions[shapeName] = true
-			api.objectMap[shapeName] = &Object{
-				Name:     shapeName,
-				Type:     ObjectTypeException,
-				DataType: shapeSpec.Type,
+		} else if shapeSpec.Type == "structure" {
+			if shapeSpec.Exception {
+				api.exceptions[shapeName] = true
+				api.objectMap[shapeName] = &Object{
+					Name:     shapeName,
+					Type:     ObjectTypeException,
+					DataType: shapeSpec.Type,
+				}
+			} else {
+				// Just a plain ol' object
+				api.objectMap[shapeName] = &Object{
+					Name:     shapeName,
+					Type:     ObjectTypeObject,
+					DataType: shapeSpec.Type,
+				}
 			}
 		} else if shapeSpec.Type == "list" {
 			api.lists[shapeName] = true


### PR DESCRIPTION
Fix two issues, one around a stack overflow that was occurring due to not
properly detecting cycles in object relationships and another where plain
old structs were not properly being added to the `API.objectMap`