### PR TITLE
Use aws-sdk-go private/model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *~
 build
+bin

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,8 @@ GO111MODULE=on
 all: test
 
 test:
-	go test -v ./...
+	go test -tags codegen -v ./...
+
+build:
+	# -tags codegen is required due to importing aws-sdk-go/private packages
+	go build -tags codegen -o bin/aws-api-tool cmd/aws-api-tool/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+GO111MODULE=on
+
+.PHONY: all test
+
+all: test
+
+test:
+	go test -v ./...

--- a/cmd/aws-api-tool/command/api.go
+++ b/cmd/aws-api-tool/command/api.go
@@ -74,12 +74,7 @@ func getAPIs(
 				continue
 			}
 		}
-		version, err := sdkHelper.APIVersion(fname)
-		if err != nil {
-			return apis, err
-		}
-		versionPath := filepath.Join(fp, version)
-		api, err := getAPIFromVersionPath(fname, versionPath)
+		api, err := apimodel.New(fname, sdkHelper)
 		if err != nil {
 			return apis, err
 		}
@@ -106,18 +101,6 @@ func getAPI(
 		return nil, fmt.Errorf("unknown API %s", alias)
 	}
 	return apis[0], nil
-}
-
-func getAPIFromVersionPath(
-	alias string,
-	versionPath string,
-) (*apimodel.API, error) {
-	// in each models/apis/$service/$version/ directory will exist files like
-	// api-2.json, docs-2.json, etc. We want to grab the API model from the
-	// api-2.json file
-	modelPath := filepath.Join(versionPath, "api-2.json")
-	docPath := filepath.Join(versionPath, "docs-2.json")
-	return apimodel.New(alias, modelPath, docPath)
 }
 
 // cloneSDKRepo git clone's the aws-sdk-go source repo into the cache and

--- a/cmd/aws-api-tool/command/api.go
+++ b/cmd/aws-api-tool/command/api.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 
 	"github.com/jaypipes/aws-api-tools/pkg/apimodel"
+	"github.com/jaypipes/aws-api-tools/pkg/model"
 )
 
 const (
@@ -50,6 +51,7 @@ func getAPIs(
 	if err != nil {
 		return nil, err
 	}
+	sdkHelper := model.NewSDKHelper(sdkPath)
 	apis := []*apimodel.API{}
 
 	destPath := filepath.Join(sdkPath, "models", "apis")
@@ -72,7 +74,7 @@ func getAPIs(
 				continue
 			}
 		}
-		version, err := getAPIVersion(fp)
+		version, err := sdkHelper.APIVersion(fname)
 		if err != nil {
 			return apis, err
 		}
@@ -104,28 +106,6 @@ func getAPI(
 		return nil, fmt.Errorf("unknown API %s", alias)
 	}
 	return apis[0], nil
-}
-
-func getAPIVersion(apiPath string) (string, error) {
-	versionDirs, err := ioutil.ReadDir(apiPath)
-	if err != nil {
-		return "", err
-	}
-	for _, f := range versionDirs {
-		version := f.Name()
-		fp := filepath.Join(apiPath, version)
-		fi, err := os.Lstat(fp)
-		if err != nil {
-			return "", err
-		}
-		if !fi.IsDir() {
-			return "", fmt.Errorf("expected to find only directories in api model directory %s but found non-directory %s", apiPath, fp)
-		}
-		// TODO(jaypipes): handle more than one version? doesn't seem like
-		// there is ever more than one.
-		return version, nil
-	}
-	return "", fmt.Errorf("expected to find at least one directory in api model directory %s", apiPath)
 }
 
 func getAPIFromVersionPath(

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jaypipes/aws-api-tools
 go 1.14
 
 require (
+	github.com/aws/aws-sdk-go v1.33.1
 	github.com/gertd/go-pluralize v0.1.1
 	github.com/getkin/kin-openapi v0.3.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -102,6 +103,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aws/aws-sdk-go v1.33.1 h1:yz9XmNzPshz/lhfAZvLfMnIS9HPo8+boGRcWqDVX+T0=
+github.com/aws/aws-sdk-go v1.33.1/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -29,6 +31,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -46,6 +49,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/apimodel/model.go
+++ b/pkg/apimodel/model.go
@@ -65,10 +65,10 @@ func New(serviceAlias string, sdkHelper *model.SDKHelper) (*API, error) {
 		return nil, err
 	}
 	return &API{
-		Alias:    apiSpec.Metadata.Alias,
-		FullName: apiSpec.Metadata.FullName,
-		Version:  apiSpec.Metadata.APIVersion,
-		Protocol: apiSpec.Metadata.Protocol,
+		Alias:    sdkmodelapi.ServiceID(sdkAPI),
+		FullName: sdkAPI.Metadata.ServiceFullName,
+		Version:  sdkAPI.Metadata.APIVersion,
+		Protocol: sdkAPI.Metadata.Protocol,
 		apiSpec:  apiSpec,
 		docSpec:  docSpec,
 		sdkAPI:   sdkAPI,

--- a/pkg/apimodel/model.go
+++ b/pkg/apimodel/model.go
@@ -10,7 +10,10 @@ import (
 	"fmt"
 	"strings"
 
+	sdkmodelapi "github.com/aws/aws-sdk-go/private/model/api"
 	oai "github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/jaypipes/aws-api-tools/pkg/model"
 )
 
 const (
@@ -45,10 +48,19 @@ type API struct {
 	docSpec   *docSpec
 	objectMap map[string]*Object
 	swagger   *oai.Swagger
+	sdkAPI    *sdkmodelapi.API
 }
 
-func New(alias string, modelPath string, docPath string) (*API, error) {
+func New(serviceAlias string, sdkHelper *model.SDKHelper) (*API, error) {
+	modelPath, docPath, err := sdkHelper.ModelAndDocsPath(serviceAlias)
+	if err != nil {
+		return nil, err
+	}
 	apiSpec, docSpec, err := parseFrom(modelPath, docPath)
+	if err != nil {
+		return nil, err
+	}
+	sdkAPI, err := sdkHelper.API(serviceAlias)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +71,7 @@ func New(alias string, modelPath string, docPath string) (*API, error) {
 		Protocol: apiSpec.Metadata.Protocol,
 		apiSpec:  apiSpec,
 		docSpec:  docSpec,
+		sdkAPI:   sdkAPI,
 	}, nil
 }
 

--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -1,0 +1,58 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package model
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+var (
+	ErrInvalidVersionDirectory = errors.New(
+		"expected to find only directories in api model directory but found non-directory",
+	)
+	ErrNoValidVersionDirectory = errors.New(
+		"no valid version directories found",
+	)
+)
+
+// SDKHelper is a helper struct that helps work with the aws-sdk-go models and
+// API model loader
+type SDKHelper struct {
+	basePath string
+}
+
+// NewSDKHelper returns a new SDKHelper object
+func NewSDKHelper(basePath string) *SDKHelper {
+	return &SDKHelper{basePath}
+}
+
+// APIVersion returns the API version (e.g. "2012-10-03") for a service API
+func (h *SDKHelper) APIVersion(serviceAlias string) (string, error) {
+	apiPath := filepath.Join(h.basePath, "models", "apis", serviceAlias)
+	versionDirs, err := ioutil.ReadDir(apiPath)
+	if err != nil {
+		return "", err
+	}
+	for _, f := range versionDirs {
+		version := f.Name()
+		fp := filepath.Join(apiPath, version)
+		fi, err := os.Lstat(fp)
+		if err != nil {
+			return "", err
+		}
+		if !fi.IsDir() {
+			return "", ErrInvalidVersionDirectory
+		}
+		// TODO(jaypipes): handle more than one version? doesn't seem like
+		// there is ever more than one.
+		return version, nil
+	}
+	return "", ErrNoValidVersionDirectory
+}


### PR DESCRIPTION
The `aws-sdk-go` project contains a `private/model/api` Go package that contains
a number of useful parsing and API management functionality. So much so, in
fact, that this private package obviates much of the custom JSON parsing that
I added to `aws-api-tools/pkg/apimodel`. I'll be replacing that package with a
`pkg/model` that uses the `aws-sdk-go/private/model/api` package directly.